### PR TITLE
Profile button reordering and fix karma configuration on stats profile type

### DIFF
--- a/src/lib/components/SideBar.svelte
+++ b/src/lib/components/SideBar.svelte
@@ -196,6 +196,24 @@
 				<Toggle checked={$profileConfig.flip} on:change={profileConfig.switchFlip}>
 					Odwróć układ
 				</Toggle>
+				<SidebarItem label="Karma" {spanClass} on:click={changeKarma}>
+					<svelte:fragment slot="icon">
+						<img src={`/profile_assets/${$profileConfig.karma}.png`} alt="karma" />
+					</svelte:fragment>
+					<svelte:fragment slot="subtext">
+						<span
+							class="ms-3 inline-flex items-center justify-center rounded-full bg-gray-200 px-2 text-sm font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300"
+						>
+							{#if $profileConfig.karma == KarmaState.Angel}
+								Dodatnia
+							{:else if $profileConfig.karma == KarmaState.Demon}
+								Ujemna
+							{:else}
+								Neutralna
+							{/if}
+						</span>
+					</svelte:fragment>
+				</SidebarItem>
 			</SidebarGroup>
 		{/if}
 

--- a/src/lib/components/SideBar.svelte
+++ b/src/lib/components/SideBar.svelte
@@ -64,19 +64,14 @@
 					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.Stats)}
 				/>
 				<SidebarDropdownItem
-					label="Statystyki na obrazku"
-					active={$profileConfig.profileType == ProfileTypeEnum.StatsOnImg}
-					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.StatsOnImg)}
+					label="Obrazek"
+					active={$profileConfig.profileType == ProfileTypeEnum.Img}
+					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.Img)}
 				/>
 				<SidebarDropdownItem
 					label="Obrazek na statystykach"
 					active={$profileConfig.profileType == ProfileTypeEnum.StatsWithImg}
 					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.StatsWithImg)}
-				/>
-				<SidebarDropdownItem
-					label="Obrazek"
-					active={$profileConfig.profileType == ProfileTypeEnum.Img}
-					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.Img)}
 				/>
 				<SidebarDropdownItem
 					label="Duża galeria"
@@ -87,6 +82,11 @@
 					label="Duża galeria na obrazku"
 					active={$profileConfig.profileType == ProfileTypeEnum.CardsOnImg}
 					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.CardsOnImg)}
+				/>
+				<SidebarDropdownItem
+					label="Statystyki na obrazku"
+					active={$profileConfig.profileType == ProfileTypeEnum.StatsOnImg}
+					on:click={() => profileConfig.setProfileType(ProfileTypeEnum.StatsOnImg)}
 				/>
 				<SidebarDropdownItem
 					label="Galeria z karcianką"


### PR DESCRIPTION
This pull request introduces two changes.
Firstly, it reorganizes the display order of profile type selection buttons to align with the sequence found in the database. 
Secondly, it resolves an issue where the karma button was missing in the profile statistics type.
These changes have been swiftly implemented to fix functionality and will be changed in the future.